### PR TITLE
Polyglot .dib file support

### DIFF
--- a/Editor/Importers.meta
+++ b/Editor/Importers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16adfebd132940d69b2c5786f3574662
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Importers/DibImporter.cs
+++ b/Editor/Importers/DibImporter.cs
@@ -1,0 +1,17 @@
+using UnityEditor.AssetImporters;
+
+namespace UnityNotebook
+{
+    // Parses .ipynb (IPython Notebook) asset files and imports them into Unity's AssetDatabase
+    [ScriptedImporter(1, "dib")]
+    public class DibImporter : ScriptedImporter
+    {
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+            var dibContent = System.IO.File.ReadAllText(ctx.assetPath);
+            var notebook = DibFormat.ParseDibToNotebook(dibContent);
+            ctx.AddObjectToAsset("main", notebook);
+            ctx.SetMainObject(notebook);
+        }
+    }
+}

--- a/Editor/Importers/DibImporter.cs
+++ b/Editor/Importers/DibImporter.cs
@@ -2,7 +2,7 @@ using UnityEditor.AssetImporters;
 
 namespace UnityNotebook
 {
-    // Parses .ipynb (IPython Notebook) asset files and imports them into Unity's AssetDatabase
+    // Parses .dib (.NET Interactive Notebook) files and imports them into Unity's AssetDatabase
     [ScriptedImporter(1, "dib")]
     public class DibImporter : ScriptedImporter
     {

--- a/Editor/Importers/DibImporter.cs.meta
+++ b/Editor/Importers/DibImporter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: da8d2e24bc684d28b1094402f680dcbd

--- a/Editor/Importers/IpynbImporter.cs
+++ b/Editor/Importers/IpynbImporter.cs
@@ -3,7 +3,7 @@ using UnityEditor.AssetImporters;
 
 namespace UnityNotebook
 {
-    // Parses .dib (.NET Interactive Notebook) files and imports them into Unity's AssetDatabase
+    // Parses .ipynb (IPython Notebook) asset files and imports them into Unity's AssetDatabase
     [ScriptedImporter(1, "ipynb")]
     public class IpynbImporter : ScriptedImporter
     {

--- a/Editor/Importers/IpynbImporter.cs
+++ b/Editor/Importers/IpynbImporter.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+using UnityEditor.AssetImporters;
+
+namespace UnityNotebook
+{
+    // Parses .dib (.NET Interactive Notebook) files and imports them into Unity's AssetDatabase
+    [ScriptedImporter(1, "ipynb")]
+    public class IpynbImporter : ScriptedImporter
+    {
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+            var json = System.IO.File.ReadAllText(ctx.assetPath);
+            var notebook = JsonConvert.DeserializeObject<Notebook>(json);
+            ctx.AddObjectToAsset("main", notebook);
+            ctx.SetMainObject(notebook);
+        }
+    }
+}

--- a/Editor/Importers/IpynbImporter.cs.meta
+++ b/Editor/Importers/IpynbImporter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 400cbf802093448aaaf006f38b8eb219

--- a/Editor/NBState.cs
+++ b/Editor/NBState.cs
@@ -7,6 +7,12 @@ using UnityEngine;
 
 namespace UnityNotebook
 {
+    public enum NotebookFormat
+    {
+        Ipynb,
+        Dib
+    }
+    
     // Singleton state object for the Notebook window
     [FilePath("UserSettings/NotebookState.asset", FilePathAttribute.Location.ProjectFolder)]
     public class NBState : ScriptableSingleton<NBState>
@@ -17,6 +23,7 @@ namespace UnityNotebook
         [SerializeField] private int runningCell;
         [SerializeField] private bool isEditMode;
         [SerializeField] private bool isJsonOutOfDate;
+        [SerializeField] private NotebookFormat preferredFormat = NotebookFormat.Ipynb;
         [SerializeField] private List<int> texHashes = new();
         [SerializeField] private List<Texture2D> texCache = new();
         
@@ -91,6 +98,16 @@ namespace UnityNotebook
                 instance.Save(true);
             }
         }
+        
+        public static NotebookFormat PreferredFormat
+        {
+            get => instance.preferredFormat;
+            set
+            {
+                instance.preferredFormat = value;
+                instance.Save(true);
+            }
+        }
 
         public static void CloseNotebook()
         {
@@ -121,8 +138,8 @@ namespace UnityNotebook
             if (nb != null)
             {
                 SaveScriptableObject();
-                var json = JsonConvert.SerializeObject(nb, Formatting.Indented);
-                System.IO.File.WriteAllText(AssetDatabase.GetAssetPath(nb), json);
+                var filePath = AssetDatabase.GetAssetPath(nb);
+                NotebookFileUtils.WriteNotebookToFile(nb, filePath);
             }
             IsJsonOutOfDate = false;
         }

--- a/Editor/NotebookSettings.cs
+++ b/Editor/NotebookSettings.cs
@@ -1,0 +1,34 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityNotebook
+{
+    public sealed class NotebookSettingsProvider : SettingsProvider
+    {
+        public NotebookSettingsProvider() : base("Project/Unity Notebook", SettingsScope.Project) {}
+
+        public override void OnGUI(string search)
+        {
+            EditorGUILayout.HelpBox(
+                "Choose the default file format for new notebooks:\n" +
+                ".ipynb - Standard Jupyter notebook with execution outputs (better for presentation)\n" +
+                ".dib - .NET Interactive notebook with only code (better for version control)",
+                MessageType.Info);
+            
+            EditorGUILayout.Space();
+            
+            EditorGUI.BeginChangeCheck();
+
+            var currentFormat = NBState.PreferredFormat;
+            var newFormat = (NotebookFormat)EditorGUILayout.EnumPopup("Default File Format", currentFormat);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                NBState.PreferredFormat = newFormat;
+            }
+        }
+
+        [SettingsProvider]
+        public static SettingsProvider CreateNotebookSettingsProvider() => new NotebookSettingsProvider();
+    }
+}

--- a/Editor/NotebookSettings.cs.meta
+++ b/Editor/NotebookSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3c3f7eb61eb24258894e5278e30a701

--- a/Editor/Serialization/DibFormat.cs
+++ b/Editor/Serialization/DibFormat.cs
@@ -117,8 +117,7 @@ namespace UnityNotebook
         {
             var dibBuilder = new StringBuilder();
             
-            const string metadata = @"
-#!meta
+            const string metadata = @"#!meta
 {
     ""kernelInfo"": {
         ""defaultKernelName"": ""csharp"",

--- a/Editor/Serialization/DibFormat.cs
+++ b/Editor/Serialization/DibFormat.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace UnityNotebook
+{
+    // Differences between .dib and .ipynb files:
+    // https://github.com/dotnet/interactive/blob/main/docs/FAQ.md#whats-the-difference-between-a-dib-file-and-an-ipynb-file
+    
+    // .dib notebook example:
+    // https://github.com/dotnet/interactive/blob/main/NotebookTestScript.dib
+
+    public static class DibFormat
+    {
+        private static readonly Regex MagicCommandRegex = new Regex(@"^#!(\w+)(.*)$", RegexOptions.Multiline);
+        private static readonly char[] NewlineChars = { '\n', '\r' };
+
+        public static Notebook ParseDibToNotebook(string dibContent)
+        {
+            var notebook = ScriptableObject.CreateInstance<Notebook>();
+            notebook.format = 4;
+            notebook.formatMinor = 2;
+            notebook.cells = new List<Cell>();
+            
+            if (string.IsNullOrWhiteSpace(dibContent))
+            {
+                return notebook;
+            }
+            
+            // Split content by magic commands
+            var lines = dibContent.Split(NewlineChars, StringSplitOptions.None);
+            var currentCell = new StringBuilder();
+            var currentCellType = CellType.Code; // Default to code
+
+            foreach (var line in lines)
+            {
+                var match = MagicCommandRegex.Match(line);
+                if (match.Success)
+                {
+                    // Save current cell if it has content, trimming trailing whitespace
+                    if (currentCell.Length > 0)
+                    {
+                        AddCellToNotebook(notebook, TrimTrailingWhitespace(currentCell.ToString()), currentCellType);
+                        currentCell.Clear();
+                    }
+
+                    // Determine cell type from magic command
+                    var magic = match.Groups[1].Value.ToLower();
+                    currentCellType = magic switch
+                    {
+                        "markdown" => CellType.Markdown,
+                        "csharp" => CellType.Code,
+                        "c#" => CellType.Code,
+                        "meta" => CellType.Raw, // Skip metadata for now
+                        _ => CellType.Code // For other magic commands, treat as code
+                    };
+                }
+                else
+                {
+                    // Skip empty lines immediately after magic commands
+                    if (currentCell.Length == 0 && string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+                    
+                    // Add line to current cell
+                    if (currentCell.Length > 0)
+                    {
+                        currentCell.AppendLine();
+                    }
+                    currentCell.Append(line);
+                }
+            }
+
+            // Add final cell if it has content, trimming trailing whitespace
+            if (currentCell.Length > 0)
+            {
+                AddCellToNotebook(notebook, TrimTrailingWhitespace(currentCell.ToString()), currentCellType);
+            }
+
+            return notebook;
+        }
+
+        private static void AddCellToNotebook(Notebook notebook, string content, CellType cellType)
+        {
+            // Skip raw cells (like meta)
+            if (cellType == CellType.Raw)
+            {
+                return;
+            }
+
+            var cell = new Cell
+            {
+                cellType = cellType,
+                source = content.Split(NewlineChars, StringSplitOptions.None),
+                outputs = new List<CellOutput>()
+            };
+
+            notebook.cells.Add(cell);
+        }
+
+        private static string TrimTrailingWhitespace(string content)
+        {
+            if (string.IsNullOrEmpty(content))
+            {
+                return content;
+            }
+            
+            // Remove trailing newlines and whitespace
+            return content.TrimEnd('\r', '\n', ' ', '\t');
+        }
+        
+        public static string NotebookToDib(Notebook notebook)
+        {
+            var dibBuilder = new StringBuilder();
+            
+            const string metadata = @"
+#!meta
+{
+    ""kernelInfo"": {
+        ""defaultKernelName"": ""csharp"",
+        ""items"": [
+            {
+                ""name"": ""csharp"",
+                ""languageName"": ""csharp"",
+                ""aliases"": []
+            }
+        ]
+    }
+}
+
+";
+            dibBuilder.Append(metadata);
+
+            foreach (var cell in notebook.cells)
+            {
+                // Add magic command based on cell type
+                string magic = cell.cellType switch
+                {
+                    CellType.Markdown => "#!markdown",
+                    CellType.Code => "#!csharp",
+                    _ => "#!meta", // Skip raw cells in output
+                };
+                dibBuilder.AppendLine(magic);
+                dibBuilder.AppendLine();
+                
+                // Add cell content
+                if (cell.source is { Length: > 0 })
+                {
+                    foreach (var line in cell.source)
+                    {
+                        dibBuilder.AppendLine(line.Trim());
+                    }
+                }
+                
+                dibBuilder.AppendLine();
+            }
+            
+            return dibBuilder.ToString();
+        }
+    }
+}

--- a/Editor/Serialization/DibFormat.cs.meta
+++ b/Editor/Serialization/DibFormat.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fc69cca54694a477f8a68d7aad86beb8

--- a/Editor/Serialization/Notebook.cs
+++ b/Editor/Serialization/Notebook.cs
@@ -1,73 +1,17 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using UnityEngine;
-using UnityEditor.AssetImporters;
 
 namespace UnityNotebook
 {
-    // Parses Jupyter Notebook asset files and imports them into Unity's AssetDatabase
-    [ScriptedImporter(1, "ipynb")]
-    public class NotebookImporter : ScriptedImporter
-    {
-        public override void OnImportAsset(AssetImportContext ctx)
-        {
-            var json = System.IO.File.ReadAllText(ctx.assetPath);
-            var notebook = JsonConvert.DeserializeObject<Notebook>(json);
-            ctx.AddObjectToAsset("main", notebook);
-            ctx.SetMainObject(notebook);
-        }
-    }
-    
     // Implementation of the Jupyter Notebook file format
     // https://nbformat.readthedocs.io/en/latest/format_description.html
     // https://github.com/jupyter/nbformat/blob/main/nbformat/v4/nbformat.v4.schema.json
-    [JsonConverter(typeof(NotebookConverter))]
+    [JsonConverter(typeof(NotebookJsonConverter))]
     public class Notebook : ScriptableObject
     {
         public int format = 4;
         public int formatMinor = 2;
         public List<Cell> cells = new();
-    }
-    
-    public class NotebookConverter : JsonConverter<Notebook>
-    {
-        public override Notebook ReadJson(JsonReader reader, System.Type objectType, Notebook existingValue, bool hasExistingValue, JsonSerializer serializer)
-        {
-            var obj = JToken.Load(reader);
-            if (!obj.HasValues)
-            {
-                return ScriptableObject.CreateInstance<Notebook>();
-            }
-            var nb = hasExistingValue ? existingValue : ScriptableObject.CreateInstance<Notebook>();
-            nb.format = obj["nbformat"]?.Value<int>() ?? 4;
-            nb.formatMinor = obj["nbformat_minor"]?.Value<int>() ?? 2;
-            var cellsList = obj["cells"];
-            if (cellsList is {HasValues: true})
-            {
-                nb.cells = cellsList.ToObject<List<Cell>>();
-            }
-            return nb;
-        }
-
-        public override void WriteJson(JsonWriter writer, Notebook value, JsonSerializer serializer)
-        {
-            var nb = new JObject
-            {
-                ["nbformat"] = value.format,
-                ["nbformat_minor"] = value.formatMinor,
-                ["metadata"] = new JObject
-                {
-                    ["kernelspec"] = new JObject
-                    {
-                        ["display_name"] = ".Net (C#)",
-                        ["language"] = "C#",
-                        ["name"] = ".net-csharp"
-                    }
-                },
-                ["cells"] = JArray.FromObject(value.cells)
-            };
-            nb.WriteTo(writer);
-        }
     }
 }

--- a/Editor/Serialization/NotebookFileUtils.cs
+++ b/Editor/Serialization/NotebookFileUtils.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using Newtonsoft.Json;
+using UnityEngine;
+
+namespace UnityNotebook
+{
+    public static class NotebookFileUtils
+    {
+        public static NotebookFormat GetFormatFromExtension(string filePath)
+        {
+            var extension = Path.GetExtension(filePath);
+            return extension == ".dib" ? NotebookFormat.Dib : NotebookFormat.Ipynb;
+        }
+        
+        public static string GetExtensionFromFormat(NotebookFormat format)
+        {
+            return format == NotebookFormat.Dib ? ".dib" : ".ipynb";
+        }
+        
+        public static bool IsDibFile(string filePath)
+        {
+            return Path.GetExtension(filePath) == ".dib";
+        }
+        
+        public static bool IsIpynbFile(string filePath)
+        {
+            return Path.GetExtension(filePath) == ".ipynb";
+        }
+        
+        public static void WriteNotebookToFile(Notebook notebook, string filePath)
+        {
+            var format = GetFormatFromExtension(filePath);
+            WriteNotebookToFile(notebook, filePath, format);
+        }
+        
+        public static void WriteNotebookToFile(Notebook notebook, string filePath, NotebookFormat format)
+        {
+            if (format == NotebookFormat.Dib)
+            {
+                var dibContent = DibFormat.NotebookToDib(notebook);
+                File.WriteAllText(filePath, dibContent);
+            }
+            else
+            {
+                var json = JsonConvert.SerializeObject(notebook, Formatting.Indented);
+                File.WriteAllText(filePath, json);
+            }
+        }
+        
+        public static string GenerateUniqueNotebookPath(string directory, string baseName, NotebookFormat format)
+        {
+            var extension = GetExtensionFromFormat(format);
+            var path = Path.Combine(directory, baseName + extension);
+            return UnityEditor.AssetDatabase.GenerateUniqueAssetPath(path);
+        }
+    }
+}

--- a/Editor/Serialization/NotebookFileUtils.cs
+++ b/Editor/Serialization/NotebookFileUtils.cs
@@ -9,7 +9,7 @@ namespace UnityNotebook
         public static NotebookFormat GetFormatFromExtension(string filePath)
         {
             var extension = Path.GetExtension(filePath);
-            return extension == ".dib" ? NotebookFormat.Dib : NotebookFormat.Ipynb;
+            return string.Equals(extension, ".dib", StringComparison.OrdinalIgnoreCase) ? NotebookFormat.Dib : NotebookFormat.Ipynb;
         }
         
         public static string GetExtensionFromFormat(NotebookFormat format)

--- a/Editor/Serialization/NotebookFileUtils.cs
+++ b/Editor/Serialization/NotebookFileUtils.cs
@@ -9,7 +9,7 @@ namespace UnityNotebook
         public static NotebookFormat GetFormatFromExtension(string filePath)
         {
             var extension = Path.GetExtension(filePath);
-            return string.Equals(extension, ".dib", StringComparison.OrdinalIgnoreCase) ? NotebookFormat.Dib : NotebookFormat.Ipynb;
+            return string.Equals(extension, ".dib") ? NotebookFormat.Dib : NotebookFormat.Ipynb;
         }
         
         public static string GetExtensionFromFormat(NotebookFormat format)

--- a/Editor/Serialization/NotebookFileUtils.cs.meta
+++ b/Editor/Serialization/NotebookFileUtils.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5a49fa38bfd314858857a58997cd3e84

--- a/Editor/Serialization/NotebookJsonConverter.cs
+++ b/Editor/Serialization/NotebookJsonConverter.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+
+namespace UnityNotebook
+{
+    public class NotebookJsonConverter : JsonConverter<Notebook>
+    {
+        public override Notebook ReadJson(JsonReader reader, System.Type objectType, Notebook existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var obj = JToken.Load(reader);
+            if (!obj.HasValues)
+            {
+                return ScriptableObject.CreateInstance<Notebook>();
+            }
+            var nb = hasExistingValue ? existingValue : ScriptableObject.CreateInstance<Notebook>();
+            nb.format = obj["nbformat"]?.Value<int>() ?? 4;
+            nb.formatMinor = obj["nbformat_minor"]?.Value<int>() ?? 2;
+            var cellsList = obj["cells"];
+            if (cellsList is {HasValues: true})
+            {
+                nb.cells = cellsList.ToObject<List<Cell>>();
+            }
+            return nb;
+        }
+
+        public override void WriteJson(JsonWriter writer, Notebook value, JsonSerializer serializer)
+        {
+            var nb = new JObject
+            {
+                ["nbformat"] = value.format,
+                ["nbformat_minor"] = value.formatMinor,
+                ["metadata"] = new JObject
+                {
+                    ["kernelspec"] = new JObject
+                    {
+                        ["display_name"] = ".Net (C#)",
+                        ["language"] = "C#",
+                        ["name"] = ".net-csharp"
+                    }
+                },
+                ["cells"] = JArray.FromObject(value.cells)
+            };
+            nb.WriteTo(writer);
+        }
+    }
+}

--- a/Editor/Serialization/NotebookJsonConverter.cs.meta
+++ b/Editor/Serialization/NotebookJsonConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d0c4edc2c4fe42f18b96d478ab508933

--- a/Editor/UI/CodeArea.cs
+++ b/Editor/UI/CodeArea.cs
@@ -16,7 +16,7 @@ namespace UnityNotebook
             editor.SaveBackup();
             editor.controlID = controlId;
             editor.position = rect;
-            editor.multiline = true;
+            editor.isMultiline = true;
             editor.style = style;
             editor.DetectFocusChange();
             HandleTextFieldEvent(rect, controlId, content, ref highlightedText, theme, style, editor);

--- a/Editor/UI/Markdown.cs
+++ b/Editor/UI/Markdown.cs
@@ -77,7 +77,6 @@ namespace UnityNotebook
         
         public static void Draw(string[] lines)
         {
-            int indent = 0;
             bool codeBlock = false;
             if (lines == null || lines.Length == 0)
             {

--- a/Editor/UI/NotebookWindow.cs
+++ b/Editor/UI/NotebookWindow.cs
@@ -174,7 +174,7 @@ namespace UnityNotebook
             {
                 var format = NBState.PreferredFormat;
                 var extension = format == NotebookFormat.Dib ? "dib" : "ipynb";
-                var path = EditorUtility.SaveFilePanelInProject("Create Notebook", "Notebook", extension, "Create Notebook");
+                var path = EditorUtility.SaveFilePanelInProject("Create Notebook", $"Notebook.{extension}", extension, "Create Notebook");
                 if (!string.IsNullOrEmpty(path))
                 {
                     if (!path.EndsWith($".{extension}"))

--- a/Editor/UI/NotebookWindow.cs
+++ b/Editor/UI/NotebookWindow.cs
@@ -165,7 +165,7 @@ namespace UnityNotebook
             const int buttonHeight = 50;
             var buttonRect = new Rect(
                 position.width / 2 - buttonWidth / 2,
-                (position.height / 2 - buttonHeight / 2) - 35,
+                (position.height / 2 - buttonHeight / 2) - 55,
                 buttonWidth,
                 buttonHeight
             );
@@ -189,8 +189,11 @@ namespace UnityNotebook
                     NBState.OpenedNotebook = nb;
                 }
             }
-
             buttonRect.y += buttonHeight + 10;
+            
+            DrawNotebookFormatPopup(buttonRect);
+
+            buttonRect.y += 40;
             if (GUI.Button(buttonRect, "Open Notebook"))
             {
                 var path = EditorUtility.OpenFilePanel("Open Notebook", Application.dataPath, "ipynb,dib");
@@ -202,7 +205,7 @@ namespace UnityNotebook
                     ChangeNotebook(nb);
                 }
             }
-
+            
             buttonRect.y += buttonHeight + 10;
 
             DrawNotebookAssetsPopup(buttonRect);
@@ -237,6 +240,19 @@ namespace UnityNotebook
             if (index >= 0)
             {
                 ChangeNotebook(notebooks[index]);
+            }
+        }
+
+        private static void DrawNotebookFormatPopup(Rect rect)
+        {
+            var formatOptions = new[] { "Jupyter (.ipynb)", "Polyglot (.dib)" };
+            var currentFormat = NBState.PreferredFormat;
+            var currentIndex = currentFormat == NotebookFormat.Ipynb ? 0 : 1;
+            
+            var index = EditorGUI.Popup(rect, currentIndex, formatOptions);
+            if (index != currentIndex)
+            {
+                NBState.PreferredFormat = index == 0 ? NotebookFormat.Ipynb : NotebookFormat.Dib;
             }
         }
 

--- a/Editor/UI/NotebookWindow.cs
+++ b/Editor/UI/NotebookWindow.cs
@@ -226,7 +226,7 @@ namespace UnityNotebook
                 return;
             }
 
-            notebooks.Sort((a, b) => string.Compare(a.name, b.name, StringComparison.Ordinal));
+            notebooks.Sort((a, b) => string.CompareOrdinal(a.name, b.name));
             var notebookNames = new string[notebooks.Count];
             for (var i = 0; i < notebooks.Count; i++)
             {

--- a/Editor/UI/Styles.cs
+++ b/Editor/UI/Styles.cs
@@ -22,10 +22,10 @@ namespace UnityNotebook
         
         public static void Init()
         {
-            // if (_initialized)
-            // {
-            //     return;
-            // }
+            if (_initialized)
+            {
+                return;
+            }
             _initialized = true;
             
             if (string.IsNullOrEmpty(_packagePath))

--- a/Editor/UI/Styles.cs
+++ b/Editor/UI/Styles.cs
@@ -22,15 +22,17 @@ namespace UnityNotebook
         
         public static void Init()
         {
-            if (_initialized)
-            {
-                return;
-            }
+            // if (_initialized)
+            // {
+            //     return;
+            // }
             _initialized = true;
             
             if (string.IsNullOrEmpty(_packagePath))
             {
-                _packagePath = UnityEditor.PackageManager.PackageInfo.FindForAssembly(Assembly.GetExecutingAssembly()).assetPath;
+                var executingAssembly = Assembly.GetExecutingAssembly();
+                var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(executingAssembly);
+                _packagePath = packageInfo.assetPath;
             }
             
             if (TextStyle == null)


### PR DESCRIPTION
This PR adds basic support for reading and writing Polyglot (.dib) notebooks, while preserving existing Jupyter (.ipynb) functionality.

**New Features**

- Added a file format dropdown to the main Notebook window when creating a new notebook.
- Added file format conversion tools to the Notebook window's context menu.

Note that since .dib is not capable of storing output cells, and the Unity Notebook GUI directly displays the contents of notebook files, output cells will disappear when the notebook is refreshed. This could be improved in the future by internally caching outputs and restoring them when the .dib file is reloaded.