### PR TITLE
fix: Add support legacy API fallback for CodeArea

### DIFF
--- a/Editor/UI/CodeArea.cs
+++ b/Editor/UI/CodeArea.cs
@@ -16,7 +16,11 @@ namespace UnityNotebook
             editor.SaveBackup();
             editor.controlID = controlId;
             editor.position = rect;
+#if UNITY_2023_1_OR_NEWER
             editor.isMultiline = true;
+#else
+            editor.multiline = true;
+#endif
             editor.style = style;
             editor.DetectFocusChange();
             HandleTextFieldEvent(rect, controlId, content, ref highlightedText, theme, style, editor);


### PR DESCRIPTION
Tested locally, dib format also worked as expected without problem in 2022.3.

<img width="643" height="904" alt="image" src="https://github.com/user-attachments/assets/5bed7e2a-26bb-4cd7-9b8f-2aabbd87ff54" />

Fixes #7 